### PR TITLE
Add options for New

### DIFF
--- a/scribble.go
+++ b/scribble.go
@@ -35,10 +35,19 @@ type (
 	}
 )
 
+type Options struct {
+	Logger
+}
+
 // New creates a new scribble database at the desired directory location, and
 // returns a *Driver to then use for interacting with the database
-func New(dir string, logger Logger) (driver *Driver, err error) {
-
+func New(dir string, opt *Options) (driver *Driver, err error) {
+	var options Options
+	if opt == nil {
+		options = Options{}
+	} else {
+		options = *opt
+	}
 	//
 	dir = filepath.Clean(dir)
 
@@ -50,18 +59,18 @@ func New(dir string, logger Logger) (driver *Driver, err error) {
 	}
 
 	//
-	if logger == nil {
-		logger = lumber.NewConsoleLogger(lumber.INFO)
+	if options.Logger == nil {
+		options.Logger = lumber.NewConsoleLogger(lumber.INFO)
 	}
 
 	//
 	driver = &Driver{
 		dir:     dir,
 		mutexes: make(map[string]sync.Mutex),
-		log:     logger,
+		log:     options.Logger,
 	}
 
-	logger.Info("Creating scribble database at '%v'...\n", dir)
+	options.Logger.Info("Creating scribble database at '%v'...\n", dir)
 
 	// create database
 	return driver, os.MkdirAll(dir, 0755)

--- a/scribble.go
+++ b/scribble.go
@@ -35,8 +35,11 @@ type (
 	}
 )
 
+// Options uses for specification of working golang-scribble
 type Options struct {
 	Logger
+	// ExistDir not creates new directory before start
+	ExistDir bool
 }
 
 // New creates a new scribble database at the desired directory location, and
@@ -53,7 +56,8 @@ func New(dir string, opt *Options) (driver *Driver, err error) {
 
 	// ensure the database location doesn't already exist (we don't want to overwrite
 	// any existing files/database)
-	if _, err := os.Stat(dir); err == nil {
+	_, err = os.Stat(dir)
+	if err == nil && !options.ExistDir {
 		fmt.Printf("Unable to create database, '%s' already exists. Please specify a different location.\n", dir)
 		os.Exit(1)
 	}
@@ -72,6 +76,10 @@ func New(dir string, opt *Options) (driver *Driver, err error) {
 
 	options.Logger.Info("Creating scribble database at '%v'...\n", dir)
 
+	//
+	if options.ExistDir && err == nil {
+		return driver, nil
+	}
 	// create database
 	return driver, os.MkdirAll(dir, 0755)
 }

--- a/scribble_test.go
+++ b/scribble_test.go
@@ -48,6 +48,14 @@ func TestNew(t *testing.T) {
 	}
 }
 
+// Checking opening exist dir
+func TestNewExist(t *testing.T) {
+	var err error
+	if db, err = New(database, &Options{ExistDir: true}); err != nil {
+		panic(err)
+	}
+}
+
 //
 func TestWriteAndRead(t *testing.T) {
 


### PR DESCRIPTION
Experimental feature for add ```Options``` to the ```New``` method. As example, i added ```ExistDir``` option, which is related with https://github.com/nanopack/yoke/issues/10 . If ```ExistDir``` is true, it not creates new dir, before starting.